### PR TITLE
refactor to not expose TriggerActions in Main

### DIFF
--- a/MainActions.elm
+++ b/MainActions.elm
@@ -7,4 +7,5 @@ import MessagesActions
 type Action
   = MessagesAction MessagesActions.Action
   | TriggerAction TriggerActions.Action
-  | ShowMessage String
+  | TriggerValue String
+  | NoOp

--- a/Trigger.elm
+++ b/Trigger.elm
@@ -4,13 +4,19 @@ import Html exposing (..)
 import Html.Events exposing (onClick)
 import Effects exposing (Effects, Never)
 import Task
-import MainActions
 import TriggerActions exposing (..)
 
-
 type alias Model =
-  String
+  { message : String
+  , valueAddress : Signal.Address String
+  }
 
+
+init : Signal.Address String -> String -> Model
+init valueAddress message =
+  { message = message
+  , valueAddress = valueAddress
+  }
 
 
 -- VIEW
@@ -20,7 +26,9 @@ view : Signal.Address Action -> Model -> Html
 view address model =
   div
     []
-    [ button [ onClick address (ShowMessage "Hello") ] [ text "Send message" ]
+    [ button
+        [ onClick address (ShowMessage model.message) ]
+        [ text "Send message" ]
     ]
 
 
@@ -28,13 +36,21 @@ view address model =
 -- UPDATE
 
 
-update : Action -> Model -> ( Model, Effects Action, Effects MainActions.Action )
+update : Action -> Model -> ( Model, Effects Action )
 update action model =
   case action of
     ShowMessage msg ->
-      let
-        mainFx =
-          Task.succeed (MainActions.ShowMessage msg)
-            |> Effects.task
-      in
-        ( model, Effects.none, mainFx )
+      ( model
+      , sendAsEffect model.valueAddress msg Tasks
+      )
+
+    Tasks _ ->
+      (model, Effects.none)
+
+
+-- here for now instead of Ext.Signal.sendAsEffect as in elm-ui from @gdotdesign
+sendAsEffect : Signal.Address a -> a -> (() -> b) -> Effects.Effects b
+sendAsEffect address value action =
+  Signal.send address value
+    |> Effects.task
+    |> Effects.map action

--- a/TriggerActions.elm
+++ b/TriggerActions.elm
@@ -3,3 +3,4 @@ module TriggerActions (..) where
 
 type Action
   = ShowMessage String
+  | Tasks ()


### PR DESCRIPTION
follows pattern seen in elm-ui by gdotdesign
generalised main model a bit
generalised trigger model a bit

have Bundled sendAsEffect  into Trigger.elm at the moment does not belong there longer term
